### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/helm/prometheus-blackbox-exporter/values.yaml
+++ b/helm/prometheus-blackbox-exporter/values.yaml
@@ -119,6 +119,9 @@ tolerations:
   - effect: NoSchedule
     operator: "Exists"
     key: node-role.kubernetes.io/master
+  - effect: NoSchedule
+    operator: "Exists"
+    key: node-role.kubernetes.io/control-plane
 affinity: {}
 
 # if the configuration is managed as secret outside the chart, using SealedSecret for example,


### PR DESCRIPTION
This PR adds a toleration for the node-role.kubernetes.io/control-plane taint to resources that already have a toleration to the deprecated node-role.kubernetes.io/master taint.
Towards giantswarm/roadmap#2471

Tested on WC with Kubernetes 1.24 & 1.23