### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.4.0] - 2023-10-18
 
 ### Added

--- a/helm/prometheus-blackbox-exporter/values.yaml
+++ b/helm/prometheus-blackbox-exporter/values.yaml
@@ -77,7 +77,7 @@ strategy:
   type: RollingUpdate
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/blackbox-exporter
   tag: v0.23.0
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
