### PR TITLE
Add http_2xx_insecure module for probing workload cluster API servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `http_2xx_insecure` module with `insecure_skip_verify: true` to support probing workload cluster API servers from the management cluster. The MC's service account CA (`http_2xx_k8sca`) only covers the MC itself; workload clusters have their own CA which is not available to the blackbox exporter, making TLS verification impossible without this module.
+
 ## [0.6.0] - 2026-03-17
 
 ### Changed

--- a/helm/prometheus-blackbox-exporter/values.yaml
+++ b/helm/prometheus-blackbox-exporter/values.yaml
@@ -148,6 +148,20 @@ config:
         follow_redirects: true
         tls_config:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    # http_2xx_insecure is intended for probing endpoints that use TLS certificates
+    # signed by a CA not available to the blackbox exporter (e.g. workload cluster API
+    # servers probed from the management cluster). The MC's service account CA only
+    # covers the MC itself, so workload cluster API servers require skipping TLS
+    # verification.
+    http_2xx_insecure:
+      prober: http
+      timeout: 5s
+      http:
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        preferred_ip_protocol: "ip4"
+        follow_redirects: true
+        tls_config:
+          insecure_skip_verify: true
     http_irsa_webhook:
       prober: http
       timeout: 5s


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35480

## Summary

- Adds a new `http_2xx_insecure` blackbox exporter module with `insecure_skip_verify: true`

## Why

When probing workload cluster API servers from the management cluster (e.g. as part of [giantswarm/cluster#788](https://github.com/giantswarm/cluster/pull/788)), TLS verification fails because:

- The existing `http_2xx_k8sca` module uses `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` — this is the **MC's** CA and only covers the MC's own API server
- Workload clusters each have their own CA, which is stored in their kubeconfig secret but is not mounted into the blackbox exporter pod
- Dynamically mounting per-cluster CA certs is not practical at scale

The `http_2xx_insecure` module allows probing workload cluster endpoints (e.g. `/readyz`) while skipping TLS verification. This is acceptable since the probes run on a trusted internal network and the goal is availability detection, not TLS validation (which is covered separately).