### PR TITLE
Add VPA for blackbox-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add VPA for `blackbox-exporter`. Uses `updateMode: Initial` for DaemonSet and `updateMode: Auto` for Deployment.
+
 ## [0.7.0] - 2026-03-24
 
 ### Added

--- a/helm/prometheus-blackbox-exporter/templates/vpa.yaml
+++ b/helm/prometheus-blackbox-exporter/templates/vpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.kind }}
+    name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  updatePolicy:
+    {{- if eq .Values.kind "DaemonSet" }}
+    updateMode: Initial
+    {{- else }}
+    updateMode: Auto
+    {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    {{- toYaml .Values.verticalPodAutoscaler.containerPolicies | nindent 4 }}
+{{- end }}

--- a/helm/prometheus-blackbox-exporter/values.yaml
+++ b/helm/prometheus-blackbox-exporter/values.yaml
@@ -382,3 +382,10 @@ dnsConfig:
 cluster:
   kubernetes:
     clusterDomain: cluster.local
+
+verticalPodAutoscaler:
+  enabled: true
+  containerPolicies:
+    - containerName: blackbox-exporter
+      controlledValues: RequestsAndLimits
+      mode: Auto


### PR DESCRIPTION
## What

Adds a `VerticalPodAutoscaler` resource for the `blackbox-exporter` workload.

VPA is enabled by default (`verticalPodAutoscaler.enabled: true`) and can be disabled via values.

## Why

The engineering team identified `prometheus-blackbox-exporter` as running without VPA on their production clusters during a resource usage assessment (2026-02-03). Tracked in giantswarm/giantswarm#35769.

## Mode selection

This chart supports both `DaemonSet` (default) and `Deployment` modes via the `kind` value. The VPA `updateMode` is set accordingly:

- **DaemonSet** → `updateMode: Initial` — VPA cannot evict DaemonSet pods, so `Auto` would silently produce recommendations without ever applying them. `Initial` sets resources at pod creation time (e.g. after a node rolls or the DaemonSet is redeployed), which is the correct and safe behaviour for DaemonSets.
- **Deployment** → `updateMode: Auto` — VPA can freely evict and resize Deployment pods.

## Changes

- `templates/vpa.yaml` — new file with mode-aware VPA resource
- `values.yaml` — added `verticalPodAutoscaler` section with default container policies