### PR TITLE
Add arm64 toleration to DaemonSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for `kubernetes.io/arch=arm64:NoSchedule` so the DaemonSet schedules on ARM worker nodes.
+
 ## [0.7.0] - 2026-03-24
 
 ### Added

--- a/helm/prometheus-blackbox-exporter/values.yaml
+++ b/helm/prometheus-blackbox-exporter/values.yaml
@@ -122,6 +122,10 @@ tolerations:
   - effect: NoSchedule
     operator: "Exists"
     key: node-role.kubernetes.io/control-plane
+  - effect: NoSchedule
+    operator: "Equal"
+    value: arm64
+    key: kubernetes.io/arch
 affinity: {}
 
 # if the configuration is managed as secret outside the chart, using SealedSecret for example,


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4301

Adds a `kubernetes.io/arch=arm64:NoSchedule` toleration so the DaemonSet schedules on ARM worker nodes (e.g. m7g instances). Without this, the blackbox-exporter skips ARM nodes.